### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,6 @@
 <%= render "shared/header" %>
 <div class='main'>
 
-  <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>
       人生を変えるフリマアプリ
@@ -17,9 +16,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
 
-  <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
       FURIMAが選ばれる3つの理由
@@ -60,9 +57,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
     <h2 class='ad-title'>
       会員数日本一位
@@ -81,9 +76,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
-  <%# FURIMAの特徴 %>
   <div class='feature-contents'>
     <h2 class='title'>
       FURIMAの特徴
@@ -118,17 +111,13 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
         <li class='list'>
           <%= link_to "#" do %>
@@ -156,10 +145,6 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% unless @items.present? %>
         <li class='list'>
           <%= link_to '#' do %>
@@ -179,11 +164,8 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
---

# What

- 商品出品内容をルートページに一覧表示する機能を実装。
- 商品出品がない場合、ダミーの出品内容を表示するように実装（出品物がない場合に備えて）。
- 商品は新規登録順に表示されるように実装（新規出品物を一覧で確認しやすくするため）。
- 商品画像がデータベースにない場合、リンク切れやエラーが発生しないように「画像がありません」と表示する仕組みを実装。

Sold outの機能は購入機能を実装時に実装予定の為、未実装の状態にしてます。

---

# Why

- ユーザーが登録した商品をルートページで一覧表示できるようにしました。
- 出品物がない場合、表示する内容がないとユーザーが迷うため、ダミーの出品内容を表示し、出品物がある場合にのみ表示されるようにしています。
- 登録内容を新しい順に表示することで、新規出品した商品がより見やすくなります。
- 画像が表示されない場合でもエラーを防ぎ、ユーザーが一覧を問題なく閲覧できるようにしました。

---

### Gayzoリンク

**動画**
[商品出品がないときダミーの出品内容が表示される](https://gyazo.com/6a9500b461bc5239180536416d00dd21)
[一覧表示を登録が新しい順に表示される](https://gyazo.com/5991d611fa974cf2a2bf0a91356e4796)